### PR TITLE
rename configuration name "dual" to "split"

### DIFF
--- a/configurations/main.xml
+++ b/configurations/main.xml
@@ -4,7 +4,7 @@
 
   <starter>
   <!-- <starter blender='path to blender executable'> -->
-    <config name='dual'>console half left, console half right</config>
+    <config name='split'>console half left, console half right</config>
     <config name='console'>console</config>
   </starter>
 


### PR DESCRIPTION
I proposse to use here the "split" name configuration instead of "dual", because it defines better the behaviour of the config. Dual is a too generic word  (it has many diferent uses in 3D)