### PR TITLE
[bugfix] cannot perform relative import

### DIFF
--- a/modules/blendervr/processor/default.py
+++ b/modules/blendervr/processor/default.py
@@ -36,7 +36,8 @@
 ## knowledge of the CeCILL license and that you accept its terms.
 ##
 
-from .. import *
+import blendervr
+from blendervr import *
 
 if is_virtual_environment():
 


### PR DESCRIPTION
This is a bugfix proposed to solve next error:

 2015-03-24 15:54:54,309 Invalid import of module "blender-vr/modules/blendervr/processor/default.py"
[...]
 2015-03-24 15:54:54,312   File "blender-vr/modules/blendervr/processor/default.py", line 39, in <module>
 2015-03-24 15:54:54,312     from .. import *
 2015-03-24 15:54:54,312 SystemError: Parent module '' not loaded, cannot perform relative import
 2015-03-24 15:54:54,312
 2015-03-24 15:54:54,313 ***************************


I got this error  while loading a .blend simulation file which has not an associated .processor.py file. So, blender-vr will try to load the file modules/blendervr/processor/default.py as processor.